### PR TITLE
feat(nvim): Debugging w/ nvim-dap

### DIFF
--- a/nvim/lua/plugins/DAP.lua
+++ b/nvim/lua/plugins/DAP.lua
@@ -13,7 +13,7 @@ return {
       dapui.setup()
 
       -- Key maps
-      vim.keymap.set("n", '<Leader>bp', dap.toggle_breakpoint, {})
+      vim.keymap.set("n", '<Leader>dt', dap.toggle_breakpoint, {}) -- debug toogle (breakpoint)
       vim.keymap.set("n", '<Leader>dc', dap.continue, {}) -- debug continue
 
 

--- a/nvim/lua/plugins/DAP.lua
+++ b/nvim/lua/plugins/DAP.lua
@@ -1,21 +1,32 @@
 return {
   {
     "mfussenegger/nvim-dap",
-    dependencie = {
-      "rcarriga/nvim-dap-ui",
+    config = function()
+      local dap = require("dap")
+
+      -- Key maps
+      -- See :help dap.txt, :help dap-mapping and :help dap-api.
+      -- debug toogle (breakpoint)
+      vim.keymap.set("n", '<Leader>dt', dap.toggle_breakpoint, {})
+      -- debug continue: Launching debug sessions and resuming execution via
+      vim.keymap.set("n", '<Leader>dc', dap.continue, {})
+      -- debug step (over): Stepping through code over the line
+      vim.keymap.set("n", '<Leader>ds', dap.step_over, {})
+      -- debug (step) into: Stepping through code into the function 
+      vim.keymap.set("n", '<Leader>di', dap.step_into, {})
+      -- debug repl: Inspecting the state via the built-in REPL
+      vim.keymap.set("n", '<Leader>dr', dap.repl.open, {})
+    end
+  },
+  {
+    "rcarriga/nvim-dap-ui",
+    dependencies = {
+      "mfussenegger/nvim-dap",
       "nvim-neotest/nvim-nio",
-      "williamboman/mason.nvim", -- same of LSP module
-      "jay-babu/mason-nvim-dap.nvim",
     },
     config = function()
       local dap = require("dap")
       local dapui = require("dapui")
-      dapui.setup()
-
-      -- Key maps
-      vim.keymap.set("n", '<Leader>dt', dap.toggle_breakpoint, {}) -- debug toogle (breakpoint)
-      vim.keymap.set("n", '<Leader>dc', dap.continue, {}) -- debug continue
-
 
       dap.listeners.before.attach.dapui_config = function()
         dapui.open()
@@ -29,7 +40,33 @@ return {
       dap.listeners.before.event_exited.dapui_config = function()
         dapui.close()
       end
+    end
+  },
+  {
+    "theHamsta/nvim-dap-virtual-text",
+    config = function ()
+      local dap_virtual_text = require("nvim-dap-virtual-text")
 
+      dap_virtual_text.setup({
+        enabled = true,                       -- enable this plugin (the default)
+        enabled_commands = true,              -- create commands 
+                                              -- * DapVirtualTextEnable 
+                                              -- * DapVirtualTextDisable 
+                                              -- * DapVirtualTextToggle 
+        highlight_changed_variables = true,   -- highlight changed values with NvimDapVirtualTextChanged, else always NvimDapVirtualText
+        highlight_new_as_changed = false,     -- highlight new variables in the same way as changed variables
+        show_stop_reason = true,              -- show stop reason when stopped for exceptions
+        commented = false,                    -- prefix virtual text with comment string
+        only_first_definition = true,         -- only show virtual text at first definition (if there are multiple)
+        all_references = false,               -- show virtual text on all all references of the variable (not only definitions)
+        clear_on_continue = false,            -- clear virtual text on "continue" (might cause flickering when stepping)
+        virt_text_pos = vim.fn.has 'nvim-0.10' == 1 and 'inline' or 'eol', -- position of virtual text, see `:h nvim_buf_set_extmark()`
+      })
+    end
+  },
+  {
+    "jay-babu/mason-nvim-dap.nvim",
+    config = function ()
       require("mason-nvim-dap").setup({
         automatic_installation = true,
       })

--- a/nvim/lua/plugins/DAP.lua
+++ b/nvim/lua/plugins/DAP.lua
@@ -1,0 +1,38 @@
+return {
+  {
+    "mfussenegger/nvim-dap",
+    dependencie = {
+      "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
+      "williamboman/mason.nvim", -- same of LSP module
+      "jay-babu/mason-nvim-dap.nvim",
+    },
+    config = function()
+      local dap = require("dap")
+      local dapui = require("dapui")
+      dapui.setup()
+
+      -- Key maps
+      vim.keymap.set("n", '<Leader>bp', dap.toggle_breakpoint, {})
+      vim.keymap.set("n", '<Leader>dc', dap.continue, {}) -- debug continue
+
+
+      dap.listeners.before.attach.dapui_config = function()
+        dapui.open()
+      end
+      dap.listeners.before.launch.dapui_config = function()
+        dapui.open()
+      end
+      dap.listeners.before.event_terminated.dapui_config = function()
+        dapui.close()
+      end
+      dap.listeners.before.event_exited.dapui_config = function()
+        dapui.close()
+      end
+
+      require("mason-nvim-dap").setup({
+        automatic_installation = true,
+      })
+    end
+  },
+}


### PR DESCRIPTION
Close #17 

Habilita funções de debugging via protocolo [DAP ](https://microsoft.github.io/debug-adapter-protocol//) no Neovim 

![Esquema de DAP no Neovim](https://github.com/paulopatto/dotfiles/assets/105045/950e052b-cc16-41f1-9070-0318e297a80d)

- :sparkles: Installed and config [nvim-dap](https://github.com/mfussenegger/nvim-dap)
- :sparkles: Installed and config [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) UI to nvim-dap
  - Add :package:  [nio](https://github.com/nvim-neotest/nvim-nio)  a library for asynchronous IO in Neovim
- :sparkles: Install [nvim-dap-virtual-ext](https://github.com/theHamsta/nvim-dap-virtual-text) 
- [BETA] [Gestão de adaptadores DAP via Mason](https://github.com/jay-babu/mason-nvim-dap.nvim)


----
### DOCS

- [DAP no Github](https://github.com/microsoft/debug-adapter-protocol)