### PR TITLE
chore(system): adds support to libff devel

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -9,7 +9,6 @@
 [gpg]
   format = ssh
 
-
 [include]
   path = ~/.gitconfig-ssh
 

--- a/install
+++ b/install
@@ -111,6 +111,7 @@ function install_base_packages() {
       gcc-c++ \
       git \
       kernel-devel \
+      libffi-devel \
       libpq-devel \
       lua \
       make \
@@ -137,6 +138,7 @@ function install_base_packages() {
       curl \
       git \
       gnupg2 \
+      libffi-dev \
       libpq-dev \
       libreadline-dev \
       lua5.3 \


### PR DESCRIPTION
This lib adds support to python _ctypes

Test the support in python with:

```bash
python3.13 -c "import _ctypes"
```