### PR TITLE
feat(neovim): Add support for DeepSeek provider in Avante.nvim

### DIFF
--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -4,7 +4,7 @@ return {
   lazy = false,
   version = false, -- Set this to "*" to always pull the latest release version, or set it to false to update to the latest code changes.
   opts = {
-    ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "cohere" | "copilot" | string
+    ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "cohere" | "copilot" | "deepseek" | string
     -- add any opts here
     -- for example
     openai = {
@@ -28,6 +28,13 @@ return {
       max_tokens = 4096,  -- Número máximo de tokens na resposta
     },
 
+    deepseek = {
+      endpoint = "https://api.deepseek.com/v1",
+      model = "deepseek-chat",
+      temperature = 0,
+      max_tokens = 4096,
+    },
+
     provider = "gemini", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
     -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
     -- currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
@@ -46,7 +53,7 @@ return {
     dual_boost = {
       enabled = false,
       first_provider = "gemini",
-      second_provider = "openai",
+      second_provider = "deepseek",
       prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
       timeout = 60000, -- Timeout in milliseconds
     },

--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -20,11 +20,19 @@ return {
       temperature = 0,
       max_tokens = 4096,
     },
-    provider = "openai", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
+    gemini = {
+      endpoint = "https://generativelanguage.googleapis.com/v1beta/models",  -- Endpoint da API do Gemini
+      -- @see https://ai.google.dev/gemini-api/docs/models/gemini
+      model = "gemini-2.0-flash",  -- Modelo do Gemini (ex: "gemini-pro" ou "gemini-ultra")
+      temperature = 0,  -- Controla a criatividade (0 para respostas mais determinísticas)
+      max_tokens = 4096,  -- Número máximo de tokens na resposta
+    },
+
+    provider = "gemini", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
     -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
     -- currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
     -- Of course, you can reduce the request frequency by increasing `suggestion.debounce`.
-    auto_suggestions_provider = "openai",
+    auto_suggestions_provider = "gemini",
 
     ---Specify the special dual_boost mode
     ---1. enabled: Whether to enable dual_boost mode. Default to false.
@@ -37,8 +45,8 @@ return {
     ---Note: This is an experimental feature and may not work as expected.
     dual_boost = {
       enabled = false,
-      first_provider = "openai",
-      second_provider = "claude",
+      first_provider = "gemini",
+      second_provider = "openai",
       prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
       timeout = 60000, -- Timeout in milliseconds
     },

--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -6,7 +6,17 @@ return {
   opts = {
     ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "cohere" | "copilot" | "deepseek" | string
     -- add any opts here
-    -- for example
+    
+
+    vendors = {
+      deepseek = {
+        __inherited_from = "openai",
+        api_key_name = "DEEPSEEK_API_KEY",
+        endpoint = "https://api.deepseek.com/v1",
+        model = "deepseek-coder", -- deeepseek-coder
+      },
+    },
+
     openai = {
       endpoint = "https://api.openai.com/v1",
       model = "gpt-4o", -- your desired model (or use gpt-4o, etc.)
@@ -28,19 +38,11 @@ return {
       max_tokens = 4096,  -- Número máximo de tokens na resposta
     },
 
-    deepseek = {
-      endpoint = "https://api.deepseek.com/v1",
-      model = "deepseek-chat",
-      temperature = 0,
-      max_tokens = 4096,
-    },
-
-
-    provider = "gemini", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
+    provider = "deepseek", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
     -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
     -- currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
     -- Of course, you can reduce the request frequency by increasing `suggestion.debounce`.
-    auto_suggestions_provider = "gemini",
+    auto_suggestions_provider = "deepseek",
 
     ---Specify the special dual_boost mode
     ---1. enabled: Whether to enable dual_boost mode. Default to false.
@@ -53,8 +55,8 @@ return {
     ---Note: This is an experimental feature and may not work as expected.
     dual_boost = {
       enabled = false,
-      first_provider = "gemini",
-      second_provider = "deepseek",
+      first_provider = "deepseek",
+      second_provider = "gemini",
       prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
       timeout = 60000, -- Timeout in milliseconds
     },


### PR DESCRIPTION
This commit introduces support for the DeepSeek API as a provider within the Avante.nvim plugin.

The configuration for the DeepSeek provider has been added to the `vendors` table, inheriting from the `openai` vendor configuration and setting the appropriate endpoint and API key.
Additionally, the default provider for both Aider mode and auto-suggestions has been switched to `deepseek`. The `dual_boost` configuration has also been updated to use `deepseek` as the primary provider.

### Key changes

* Added `deepseek` to the list of supported providers in `avante.lua`.
* Configured the DeepSeek vendor with its specific API endpoint, model (`deepseek-coder`), and API key environment variable (`DEEPSEEK_API_KEY`).
* Set `deepseek` as the default provider for both Aider mode and auto-suggestions.
* Updated the `dual_boost` configuration to use `deepseek` as the primary provider and `gemini` as the secondary.