### PR TITLE
feat(neovim): vim-floaterm: Terminal manager for (neo)vim

### DIFF
--- a/nvim/lua/plugins/floaterm.lua
+++ b/nvim/lua/plugins/floaterm.lua
@@ -1,0 +1,20 @@
+return {
+  "voldikss/vim-floaterm",
+  lazy = false,
+  config = function()
+    -- Você pode adicionar configurações aqui, se necessário.
+    -- Por exemplo, para definir opções globais:
+    vim.g.floaterm_width = 0.8
+    vim.g.floaterm_height = 0.8
+    vim.g.floaterm_position = "center"
+    vim.g.floaterm_auto_close = 1
+
+    -- Mapeamento de teclado para abrir/fechar o Floaterm
+    vim.keymap.set("n", "<Leader>nt", ":FloatermToggle<CR>", { desc = "Toggle Floaterm" })
+    vim.keymap.set("n", "<Leader>tt", ":FloatermToggle<CR>", { desc = "Toggle Floaterm" })
+  end,
+  dependencies = {
+    "nvim-lua/plenary.nvim", -- Se o plugin tiver dependências
+  },
+}
+


### PR DESCRIPTION
## Terminal manager for (neo)vim

Source: https://github.com/voldikss/vim-floaterm

![91380268-2cd24d00-e857-11ea-8dbd-d39a0bbb105e](https://github.com/user-attachments/assets/7fe56071-2eab-4f37-a4bc-f06ec183ea52)

### Features ✨ 

- Manage multiple terminal instances
- Customizable terminal window style
- Switch/preview floating terminal buffers using fuzzy-finder plugins such as [denite.nvim](https://github.com/Shougo/denite.nvim) or [fzf](https://github.com/junegunn/fzf), etc.
- Use with other external command-line tools(ranger, fzf, ripgrep etc.)
- Use as a custom task runner for [asynctasks.vim](https://github.com/skywind3000/asynctasks.vim) or [asyncrun.vim](https://github.com/skywind3000/asyncrun.vim)

#### Keybindings ⌨️ 

- new term: `<leader>nt`: New Term
- toggle floaterm: `<leader>tt`: Toggle Term

#### Install dependencies 📦 :

- `pip3 install neovim-remote` to allow floaterm to open windows inside neovim.

### REFERENCES 📚 :

[Youtube Video: Vim Plugin Highlight: floaterm! Floating terminals!](https://youtu.be/QzlwC-AUY-U?si=cDlvadhVSd3VcxeM)