### PR TITLE
fix(nvim): Apply patch  to update treesiter with neovim 0.12

### DIFF
--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -1,10 +1,12 @@
 -- Treesitter configs
 return {
   "nvim-treesitter/nvim-treesitter",
-  build = ":TSUpdate",
+  branch = "main",
+  lazy = false,
+  build = ":STUpdate",
   config = function()
-    local treesitter_configs = require("nvim-treesitter.configs")
-    treesitter_configs.setup({
+    local treesitter_configs = require("nvim-treesitter")
+    require("nvim-treesitter").setup({
       highlight = {
         enable = true,
         additional_vim_regex_highlighting = { "ruby" },


### PR DESCRIPTION
Following:

- https://www.qu8n.com/posts/treesitter-migration-guide-for-nvim-0-12
- https://github.com/nvim-treesitter/nvim-treesitter
- https://github.com/romus204/tree-sitter-manager.nvim


Open #105
